### PR TITLE
lowered cpu time needed to keep the container running

### DIFF
--- a/docker-start.sh
+++ b/docker-start.sh
@@ -4,4 +4,4 @@
 
 trap "echo Shutting down ...; ./chia.bin stop all -d; exit 0" SIGINT SIGTERM
 
-while true; do sleep 1; done
+tail -F /dev/null


### PR DESCRIPTION
`tail -F /dev/null` has the same effect as `while true ...` and keeps the container running.

`Tail` requires less cpu time and is therefore 'greener' in marketing terms.

Based on quick benchmark:
![grafik](https://github.com/madMAx43v3r/chia-gigahorse/assets/1436672/6be5a6bd-8a43-4177-9734-db28a43e790e)
