### PR TITLE
Fix harvester docker setups

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,9 +33,6 @@ done
 if [[ ${CHIA_SERVICES} == "harvester" ]]; then
   if [[ -n ${CHIA_FARMER_ADDRESS} || -n ${CHIA_FARMER_PORT} || -n ${CHIA_CA} ]]; then
     ./chia.bin init -c "${CHIA_CA}" && ./chia.bin configure --set-farmer-peer "${CHIA_FARMER_ADDRESS}:${CHIA_FARMER_PORT}"
-  else
-    echo "A farmer peer address, port, and ca path are required."
-    exit
   fi
 fi
 


### PR DESCRIPTION
Currently if you specifiy the necessary environment flags for easier remote harvester setup, the image will re-init the ssl directory on every startup.
If one does not specify them it just exits.

This PR fixes this by only initing the directory if the flags are present and continuing on as usual if they are not.