### PR TITLE
Add support for building standalone recompute docker images

### DIFF
--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -23,7 +23,7 @@ jobs:
       packages: write
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: chia-recompute
+      IMAGE_NAME: ${{ github.repository }}-recompute
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -29,19 +29,19 @@ jobs:
       matrix:
         include:
           - final-build-stage: 'base'
-            latest-tag-behaviour: auto
+            latest-tag-behaviour: true
             version-suffix: ''
             suffix-onlatest: false
           - final-build-stage: nvidia
-            latest-tag-behaviour: auto
+            latest-tag-behaviour: true
             version-suffix: '-nvidia'
             suffix-onlatest: true
           - final-build-stage: intel
-            latest-tag-behaviour: auto
+            latest-tag-behaviour: true
             version-suffix: '-intel'
             suffix-onlatest: true
           - final-build-stage: amd
-            latest-tag-behaviour: auto
+            latest-tag-behaviour: true
             version-suffix: '-amd'
             suffix-onlatest: true
     steps:
@@ -56,8 +56,6 @@ jobs:
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}
-          tags: |
-            type=raw,value=latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -23,7 +23,7 @@ jobs:
       packages: write
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}-recompute
+      IMAGE_NAME: chia-recompute
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -3,7 +3,7 @@ name: Docker Recompute
 on:
   push:
     branches:
-      - 'master'
+      - '**'
     paths:
       - 'chiapos/linux/x86_64/chia_recompute*'
   workflow_dispatch:

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -23,7 +23,7 @@ jobs:
       packages: write
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: chia-recompute
+      IMAGE_NAME: ${{ github.repository_owner }}/chia-recompute
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -52,7 +52,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           context: chiapos/linux/x86_64
           target: ${{ matrix.final-build-stage }}
-          push: ${{ github.ref == 'refs/heads/master' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -56,6 +56,8 @@ jobs:
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}
+          tags: |
+            type=raw,latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -1,0 +1,78 @@
+name: Docker Recompute
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'chiapos/linux/x86_64/chia_recompute*'
+  workflow_dispatch:
+
+# Automatically cancel previous runs for the same ref (i.e. branch) and event type. The latter component prevents
+# manually dispatched events from being cancelled by pushes to the `master` branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-chia-recompute-image:
+    name: Build and push chia-recompute image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: chia-recompute
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - final-build-stage: 'base'
+            latest-tag-behaviour: auto
+            version-suffix: ''
+            suffix-onlatest: false
+          - final-build-stage: nvidia
+            latest-tag-behaviour: auto
+            version-suffix: '-nvidia'
+            suffix-onlatest: true
+          - final-build-stage: intel
+            latest-tag-behaviour: auto
+            version-suffix: '-intel'
+            suffix-onlatest: true
+          - final-build-stage: amd
+            latest-tag-behaviour: auto
+            version-suffix: '-amd'
+            suffix-onlatest: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ matrix.latest-tag-behaviour }}
+            suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: chiapos/linux/x86_64
+          target: ${{ matrix.final-build-stage }}
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-recompute.yaml
+++ b/.github/workflows/docker-recompute.yaml
@@ -56,6 +56,8 @@ jobs:
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
             suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}
+          tags: |
+            type=raw,value=latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/chiapos/README.md
+++ b/chiapos/README.md
@@ -104,3 +104,122 @@ max_farm_size_TiB = (plot_size_GiB / 1024) * plot_filter * 8 * 1000 / total_look
 - `CHIAPOS_RECOMPUTE_TIMEOUT`: timeout in milliseconds for processing a request (default = 5000)
 - `CHIAPOS_RECOMPUTE_CONNECT_TIMEOUT`: timeout in milliseconds for connecting to a server (default = 2000)
 - `CHIAPOS_RECOMPUTE_RETRY_INTERVAL`: interval in seconds how often to retry using a previously failed server (default = 100)
+
+# Remote Compute Docker Usage
+
+The Dockerfile file uses multiple build stages to support 4 different applications CPU-Only, NVIDIA-GPU, Intel-GPU, and AMD-GPU.
+
+## CPU-Only
+
+Docker Run Example:
+
+`docker run --rm -it -p 11989:11989 ghcr.io/madmax43v3r/chia-recompute:latest`
+
+Docker Compose Example:
+```yml
+version: '3'
+services:
+  chia:
+    image: ghcr.io/madmax43v3r/chia-recompute:latest
+    restart: unless-stopped
+    ports:
+      - "11989:11989"
+    environment:
+      TZ: 'America/Chicago'
+#      CHIA_RECOMPUTE_PORT: 12000
+### Enable Proxy Mode ###
+#      CHIA_RECOMPUTE_PROXY: 'true'
+#      CHIA_RECOMPUTE_NODES: 192.168.1.1,192.168.1.2:11990
+### GPU Specific Options ###
+#      CHIAPOS_MAX_CUDA_DEVICES: 0
+#      CHIAPOS_MAX_OPENCL_DEVICES: 0
+#      CUDA_VISIBLE_DEVICES: 0   
+```
+## NVIDIA-GPU
+
+Docker Run Example:
+
+`docker run --rm -it --runtime=nvidia -p 11989:11989 ghcr.io/madmax43v3r/chia-recompute:latest-nvidia`
+
+Docker Compose Example:
+```yml
+version: '3'
+services:
+  chia:
+    image: ghcr.io/madmax43v3r/chia-recompute:latest-nvidia
+    restart: unless-stopped
+    runtime: nvidia
+    ports:
+      - "11989:11989"
+    environment:
+      TZ: 'America/Chicago'
+#      CHIA_RECOMPUTE_PORT: 12000
+### Enable Proxy Mode ###
+#      CHIA_RECOMPUTE_PROXY: 'true'
+#      CHIA_RECOMPUTE_NODES: 192.168.1.1,192.168.1.2:11990
+### GPU Specific Options ###
+#      CHIAPOS_MAX_CUDA_DEVICES: 0
+#      CHIAPOS_MAX_OPENCL_DEVICES: 0
+#      CUDA_VISIBLE_DEVICES: 0 
+```
+Note: for nvidia you also need the `NVIDIA Container Toolkit` installed on the host, for more info please see: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker
+
+## Intel-GPU
+
+Docker Run Example:
+
+`docker run --rm -it --device=/dev/dri -p 11989:11989 ghcr.io/madmax43v3r/chia-recompute:latest-intel`
+
+Docker Compose Example:
+```yml
+version: '3'
+services:
+  chia:
+    image: ghcr.io/madmax43v3r/chia-recompute:latest-intel
+    restart: unless-stopped
+    devices:
+      - /dev/dri:/dev/dri
+    ports:
+      - "11989:11989"
+    environment:
+      TZ: 'America/Chicago'
+#      CHIA_RECOMPUTE_PORT: 12000
+### Enable Proxy Mode ###
+#      CHIA_RECOMPUTE_PROXY: 'true'
+#      CHIA_RECOMPUTE_NODES: 192.168.1.1,192.168.1.2:11990
+### GPU Specific Options ###
+#      CHIAPOS_MAX_CUDA_DEVICES: 0
+#      CHIAPOS_MAX_OPENCL_DEVICES: 0
+#      CUDA_VISIBLE_DEVICES: 0 
+```
+Note: for ARC GPU's you will need to be running kernel 6.2+ on your docker host
+
+## AMD-GPU
+
+Docker Run Example:
+
+`docker run --rm -it --device=/dev/kfd --device=/dev/dri -p 11989:11989 ghcr.io/madmax43v3r/chia-recompute:latest-amd`
+
+Docker Compose Example:
+```yml
+version: '3'
+services:
+  chia:
+    image: ghcr.io/madmax43v3r/chia-recompute:latest-amd
+    restart: unless-stopped
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    ports:
+      - "11989:11989"
+    environment:
+      TZ: 'America/Chicago'
+#      CHIA_RECOMPUTE_PORT: 12000
+### Enable Proxy Mode ###
+#      CHIA_RECOMPUTE_PROXY: 'true'
+#      CHIA_RECOMPUTE_NODES: 192.168.1.1,192.168.1.2:11990
+### GPU Specific Options ###
+#      CHIAPOS_MAX_CUDA_DEVICES: 0
+#      CHIAPOS_MAX_OPENCL_DEVICES: 0
+#      CUDA_VISIBLE_DEVICES: 0 
+```

--- a/chiapos/linux/x86_64/Dockerfile
+++ b/chiapos/linux/x86_64/Dockerfile
@@ -28,7 +28,9 @@ RUN apt-get update && apt-get install -y intel-opencl-icd \
 FROM base AS amd
 ARG AMD_DRIVER=amdgpu-pro-20.40-1147286-ubuntu-20.04.tar.xz
 ARG AMD_DRIVER_URL=https://drivers.amd.com/drivers/linux
-RUN mkdir -p /tmp/opencl-driver-amd \
+RUN apt-get update && apt-get install -y \
+	curl xz-utils \
+    && mkdir -p /tmp/opencl-driver-amd \
     && cd /tmp/opencl-driver-amd \
     && curl --referer ${AMD_DRIVER_URL} -O ${AMD_DRIVER_URL}/${AMD_DRIVER} \
     && tar -Jxvf ${AMD_DRIVER} \

--- a/chiapos/linux/x86_64/Dockerfile
+++ b/chiapos/linux/x86_64/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:12-slim AS base
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+	ocl-icd-libopencl1 \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /chia-recompute
+
+COPY docker-start.sh chia_recompute* .
+ENV CHIA_RECOMPUTE_PORT="11989"
+EXPOSE 11989
+
+CMD ["./docker-start.sh"]
+
+
+FROM base AS nvidia
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+
+FROM base AS intel
+RUN apt-get update && apt-get install -y intel-opencl-icd \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+FROM base AS amd
+ARG AMD_DRIVER=amdgpu-pro-20.40-1147286-ubuntu-20.04.tar.xz
+ARG AMD_DRIVER_URL=https://drivers.amd.com/drivers/linux
+RUN mkdir -p /tmp/opencl-driver-amd \
+    && cd /tmp/opencl-driver-amd \
+    && curl --referer ${AMD_DRIVER_URL} -O ${AMD_DRIVER_URL}/${AMD_DRIVER} \
+    && tar -Jxvf ${AMD_DRIVER} \
+    && cd amdgpu-pro-20.40-1147286-ubuntu-20.04 \
+    && ./amdgpu-install --opencl=legacy,pal --headless --no-dkms -y \
+    && rm -rf /tmp/opencl-driver-amd \
+    && rm -rf /var/lib/apt/lists/*

--- a/chiapos/linux/x86_64/docker-start.sh
+++ b/chiapos/linux/x86_64/docker-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ ${CHIA_RECOMPUTE_PROXY} == "true" ]]; then
+  if [[ -n ${CHIA_RECOMPUTE_NODES} ]]; then
+    nodes=""
+    for n in ${CHIA_RECOMPUTE_NODES//,/ }; do
+      nodes+=" -n ${n}"
+    done
+    ./chia_recompute_proxy -p ${CHIA_RECOMPUTE_PORT} ${nodes}
+  else
+    echo "At least one compute server must be specified to run the proxy"
+    exit
+  fi
+else
+  ./chia_recompute_server -p ${CHIA_RECOMPUTE_PORT}
+fi


### PR DESCRIPTION
This pr will allow automatic building of non-versioned docker images for the remote compute server/proxy